### PR TITLE
Add category and company seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,32 @@ user2 = User.create(email: 'test2@test.com', name: 'test2', password: 'password'
   end
 end
 
+# Create some categories with a simple parent/child hierarchy
+tech = Category.create!(name: 'Solar Technology')
+%w[Panels Inverters Batteries 'Mounting Systems'].each do |child_name|
+  Category.create!(name: child_name, parent: tech)
+end
+
+services = Category.create!(name: 'Services')
+%w[Installation Maintenance Consulting Financing Monitoring].each do |child_name|
+  Category.create!(name: child_name, parent: services)
+end
+
+# Create five companies tied to the users created above
+5.times do |i|
+  owner = i.even? ? user1 : user2
+  Company.create!(
+    name: "Company #{i + 1}",
+    description: "Demo company number #{i + 1}",
+    location: "City #{i + 1}",
+    target_segment: Company.target_segments.keys.sample,
+    user: owner,
+    verified: [true, false].sample,
+    annual_energy_output: rand(500..1500),
+    installation_count: rand(10..100)
+  )
+end
+
 if Rails.env.development?
   AdminUser.create!(email: 'admin@example.com', password: 'password', password_confirmation: 'password', role: :admin)
 end


### PR DESCRIPTION
## Summary
- seed example categories with hierarchy
- seed sample companies linked to seeded users

## Testing
- `bundle exec rails db:seed` *(fails: pending migrations)*

------
https://chatgpt.com/codex/tasks/task_e_6883d293dd6083268ef642806739c53d